### PR TITLE
Bug/nyt error handling

### DIFF
--- a/client/src/components/DisasterPage.js
+++ b/client/src/components/DisasterPage.js
@@ -8,6 +8,7 @@ const DisasterPage = ({
   articles,
   disaster,
   disasterTypes,
+  error,
   longDescription,
   onClick,
   shortDescription,
@@ -35,6 +36,7 @@ const DisasterPage = ({
         {showLongDescription ? 'Show less' : 'Show more'}
       </button>
       <h3>Related Stories</h3>
+      {error && <p>{error}</p>}
       {articles.map(article => (
         <ArticleCard article={article} />
       ))}

--- a/client/src/components/DisasterPage.js
+++ b/client/src/components/DisasterPage.js
@@ -32,9 +32,11 @@ const DisasterPage = ({
       <p className="description">
         {showLongDescription ? longDescription : shortDescription}
       </p>
-      <button className="toggle-button" onClick={toggleDescription}>
-        {showLongDescription ? 'Show less' : 'Show more'}
-      </button>
+      {longDescription && (
+        <button className="toggle-button" onClick={toggleDescription}>
+          {showLongDescription ? 'Show less' : 'Show more'}
+        </button>
+      )}
       <h3>Related Stories</h3>
       {error && <p>{error}</p>}
       {articles.map(article => (

--- a/client/src/components/DisasterPageWrapper.js
+++ b/client/src/components/DisasterPageWrapper.js
@@ -6,6 +6,7 @@ import DisasterPage from './DisasterPage';
 class DisasterPageWrapper extends React.Component {
   state = {
     articles: [],
+    error: '',
     longDescription: '',
     shortDescription: '',
     showLongDescription: false
@@ -13,13 +14,6 @@ class DisasterPageWrapper extends React.Component {
 
   async componentDidMount() {
     const { disaster, selectedCountry } = this.props;
-
-    const articles = await axios.get('/nyt', {
-      params: {
-        name: disaster.name,
-        country: selectedCountry.name
-      }
-    });
 
     const longDescription = disaster.description
       .replace(/\(http.*\)/gi, '')
@@ -29,11 +23,27 @@ class DisasterPageWrapper extends React.Component {
       .replace(/\[<img.*>\]/g, '');
     const shortDescription = longDescription.split('. ', 3).join('. ') + '.';
 
-    this.setState(() => ({
-      articles: articles.data,
-      longDescription,
-      shortDescription
-    }));
+    const articles = await axios.get('/nyt', {
+      params: {
+        name: disaster.name,
+        country: selectedCountry.name
+      }
+    });
+    console.log(articles);
+
+    if (articles.data.error) {
+      this.setState(() => ({
+        error: articles.data.error,
+        longDescription,
+        shortDescription
+      }));
+    } else {
+      this.setState(() => ({
+        articles: articles.data,
+        longDescription,
+        shortDescription
+      }));
+    }
   }
 
   toggleDescription = () => {

--- a/server/routes/nyt.js
+++ b/server/routes/nyt.js
@@ -40,6 +40,9 @@ router.get('/', function(req, res) {
       });
 
       res.json(articles);
+    })
+    .catch(err => {
+      res.send({ error: 'Could not load articles' });
     });
 });
 


### PR DESCRIPTION
Send error response if error in fetching nyt article data, correctly display error on disaster page. Disaster description now loads correctly even if /nyt endpoint returns an error.